### PR TITLE
Symlink DataCollectionVsTelemetry.md from Readme.md

### DIFF
--- a/DataCollectionVsTelemetry.md
+++ b/DataCollectionVsTelemetry.md
@@ -1,3 +1,5 @@
+*See also: [OtherComments.md](OtherComments.md)*
+
 # Data Collection vs Telemetry in Audacity
 
 Audacity PR #835 is a mess on many levels. Problems that exist with this PR are

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,1 @@
+DataCollectionVsTelemetry.md


### PR DESCRIPTION
Github understands symlinks for Readme.md and displays them as any other Readme file, so I thought your comments showing up when browsing the repo root itself would be nicer. 

Also added a link to `OtherComments.md` at the top of `DataCollectionVsTelemetry.md`.

Feel free to reject if you intentionally didn't want to have a Readme. Also thanks a lot for taking the time to write these very informative comments!